### PR TITLE
chore(MOB-2532): add conventional-commit workflow

### DIFF
--- a/workflow-templates/conventional-commit.yml
+++ b/workflow-templates/conventional-commit.yml
@@ -16,4 +16,4 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: qhrtech/gh-action-semantic-release@v1
+      - uses: qhrtech/gh-action-semantic-pull-request@v1

--- a/workflow-templates/conventional-commit.yml
+++ b/workflow-templates/conventional-commit.yml
@@ -17,7 +17,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: qhrtech/gh-action-semantic-release@v1
-        with:
-          requireScope: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/conventional-commit.yml
+++ b/workflow-templates/conventional-commit.yml
@@ -16,4 +16,7 @@ jobs:
         with:
           requireScope: true
         env:
+          # The workflow permissions need to be set to "read and write permissions", because
+          # otherwise the token isn't granted read permissions to pull-requests:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/conventional-commit.yml
+++ b/workflow-templates/conventional-commit.yml
@@ -1,0 +1,19 @@
+name: "Conventional Commit"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        with:
+          requireScope: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/conventional-commit.yml
+++ b/workflow-templates/conventional-commit.yml
@@ -16,7 +16,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: qhrtech/gh-action-semantic-release@v1
         with:
           requireScope: true
         env:

--- a/workflow-templates/conventional-commit.yml
+++ b/workflow-templates/conventional-commit.yml
@@ -1,3 +1,4 @@
+
 name: "Conventional Commit"
 
 on:
@@ -6,6 +7,9 @@ on:
       - opened
       - edited
       - synchronize
+
+permissions:
+  pull-requests: read
 
 jobs:
   main:
@@ -16,7 +20,4 @@ jobs:
         with:
           requireScope: true
         env:
-          # The workflow permissions need to be set to "read and write permissions", because
-          # otherwise the token isn't granted read permissions to pull-requests:
-          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Testing:

For security reasons, github won't trigger this unless it's already merged to the main branch: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

So there's no real way to test this other than creating a private repo and copying the workflow to it.